### PR TITLE
fix (settings): close move dialog on folder move completion

### DIFF
--- a/electron-main/customFolderLocationOperation.js
+++ b/electron-main/customFolderLocationOperation.js
@@ -81,6 +81,12 @@ const moveFolderContents = async (src, dest, event) => {
     }
     // 3. Remove empty directories in src
     await removeEmptyDirs(src);
+    if (event)
+        event.sender.send("move-folder-progress", {
+            moved,
+            total,
+            phase: "delete-done",
+        });
 };
 
 // IPC: Set custom save folder with validation and move contents

--- a/src/components/setting_page/SaveFolderSettings.jsx
+++ b/src/components/setting_page/SaveFolderSettings.jsx
@@ -60,7 +60,6 @@ const SaveFolderSettings = () => {
                 if (result.success) {
                     setCustomFolder(selected);
                     setCurrentFolder(result.newPath || selected);
-                    sonnerSuccessToast(t("toast.folderChanged"));
                 } else {
                     let msg = t(`toast.${result.error}`);
                     if (result.reason) {
@@ -86,7 +85,6 @@ const SaveFolderSettings = () => {
             setMoveProgress(null);
             setCustomFolder(null);
             setCurrentFolder(result.newPath || "");
-            sonnerSuccessToast(t("toast.folderChanged"));
         } finally {
             setLoading(false);
         }

--- a/src/components/setting_page/SaveFolderSettings.jsx
+++ b/src/components/setting_page/SaveFolderSettings.jsx
@@ -26,11 +26,16 @@ const SaveFolderSettings = () => {
         const handler = (_event, data) => {
             setMoveProgress(data);
             setMoveDialogOpen(true);
+            if (data.phase === "delete-done") {
+                setMoveDialogOpen(false);
+                setMoveProgress(null);
+                sonnerSuccessToast(t("toast.folderChanged"));
+            }
         };
         window.electron.ipcRenderer.on("move-folder-progress", handler);
         return () =>
             window.electron.ipcRenderer.removeAllListeners("move-folder-progress", handler);
-    }, []);
+    }, [t]);
 
     const handleChooseFolder = async () => {
         setLoading(true);


### PR DESCRIPTION
When the file operation is too quick, the dialog could get stuck. This is fixed by updating the file operation logic in `customFolderLocationOperation.js` to emit a `delete-done` phase via the `move-folder-progress` event.

The UI now listens for this phase and closes the dialog when received, ensuring the progress dialog always closes correctly, even for fast operations.