### PR TITLE
refactor(theme): decouple theme detection logic, update waveform theme hook

### DIFF
--- a/src/components/conversation_page/WatchAndStudyTab.jsx
+++ b/src/components/conversation_page/WatchAndStudyTab.jsx
@@ -3,47 +3,18 @@ import { defaultLayoutIcons, DefaultVideoLayout } from "@vidstack/react/player/l
 import "@vidstack/react/player/styles/default/layouts/video.css";
 import "@vidstack/react/player/styles/default/theme.css";
 import PropTypes from "prop-types";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { IoInformationCircleOutline } from "react-icons/io5";
 import { isElectron } from "../../utils/isElectron";
-import { useTheme } from "../../utils/ThemeContext/useTheme";
+import { useAutoDetectTheme } from "../../utils/ThemeContext/useAutoDetectTheme";
 
 const WatchAndStudyTab = ({ videoUrl, subtitleUrl, dialog, skillCheckmark }) => {
     const { t } = useTranslation();
     const [highlightState, setHighlightState] = useState({});
     const [iframeLoading, setiFrameLoading] = useState(true);
 
-    const { theme } = useTheme();
-    const [, setCurrentTheme] = useState(theme);
-    const [isDarkMode, setIsDarkMode] = useState(false);
-
-    useEffect(() => {
-        const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-
-        const updateTheme = () => {
-            if (theme === "auto") {
-                const systemPrefersDark = mediaQuery.matches;
-                setCurrentTheme(systemPrefersDark ? "dark" : "light");
-                setIsDarkMode(systemPrefersDark);
-            } else {
-                setCurrentTheme(theme);
-                setIsDarkMode(theme === "dark");
-            }
-        };
-
-        // Initial check and listener
-        updateTheme();
-        if (theme === "auto") {
-            mediaQuery.addEventListener("change", updateTheme);
-        }
-
-        return () => {
-            mediaQuery.removeEventListener("change", updateTheme);
-        };
-    }, [theme]);
-
-    const videoColorScheme = isDarkMode ? "dark" : "light";
+    const { autoDetectedTheme } = useAutoDetectTheme();
 
     const handleIframeLoad = () => setiFrameLoading(false);
 
@@ -59,8 +30,8 @@ const WatchAndStudyTab = ({ videoUrl, subtitleUrl, dialog, skillCheckmark }) => 
         <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
             <div>
                 <div className="text-xl font-semibold">{t("tabConversationExam.watchCard")}</div>
-                <div className="divider divider-secondary mb-4 mt-0"></div>
-                <div className="top-[calc(14rem)] bg-base-100 md:sticky md:z-10">
+                <div className="divider divider-secondary mt-0 mb-4"></div>
+                <div className="bg-base-100 top-[calc(14rem)] md:sticky md:z-10">
                     <div className="aspect-video">
                         <div className="relative h-full w-full">
                             {isElectron() && videoUrl && videoUrl.startsWith("http://localhost") ? (
@@ -68,7 +39,7 @@ const WatchAndStudyTab = ({ videoUrl, subtitleUrl, dialog, skillCheckmark }) => 
                                     <MediaProvider />
                                     <DefaultVideoLayout
                                         icons={defaultLayoutIcons}
-                                        colorScheme={videoColorScheme}
+                                        colorScheme={autoDetectedTheme}
                                     />
                                     <Track
                                         src={subtitleUrl}
@@ -110,8 +81,8 @@ const WatchAndStudyTab = ({ videoUrl, subtitleUrl, dialog, skillCheckmark }) => 
             </div>
             <div>
                 <div className="text-xl font-semibold">{t("tabConversationExam.studyCard")}</div>
-                <div className="divider divider-secondary mb-4 mt-0"></div>
-                <div className="collapse collapse-arrow bg-base-200 dark:bg-slate-700">
+                <div className="divider divider-secondary mt-0 mb-4"></div>
+                <div className="collapse-arrow bg-base-200 collapse dark:bg-slate-700">
                     <input type="checkbox" />
                     <button type="button" className="collapse-title text-start font-semibold">
                         {t("tabConversationExam.studyExpandBtn")}

--- a/src/components/exam_page/WatchAndStudyTab.jsx
+++ b/src/components/exam_page/WatchAndStudyTab.jsx
@@ -3,11 +3,11 @@ import { defaultLayoutIcons, DefaultVideoLayout } from "@vidstack/react/player/l
 import "@vidstack/react/player/styles/default/layouts/video.css";
 import "@vidstack/react/player/styles/default/theme.css";
 import PropTypes from "prop-types";
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { IoCloseOutline, IoInformationCircleOutline } from "react-icons/io5";
 import { isElectron } from "../../utils/isElectron";
-import { useTheme } from "../../utils/ThemeContext/useTheme";
+import { useAutoDetectTheme } from "../../utils/ThemeContext/useAutoDetectTheme";
 
 const WatchAndStudyTab = ({ videoUrl, subtitleUrl, taskData, dialog, skills }) => {
     const { t } = useTranslation();
@@ -17,36 +17,7 @@ const WatchAndStudyTab = ({ videoUrl, subtitleUrl, taskData, dialog, skills }) =
     const imageModalRef = useRef(null);
     const [iframeLoading, setiFrameLoading] = useState(true);
 
-    const { theme } = useTheme();
-    const [, setCurrentTheme] = useState(theme);
-    const [isDarkMode, setIsDarkMode] = useState(false);
-
-    useEffect(() => {
-        const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-
-        const updateTheme = () => {
-            if (theme === "auto") {
-                const systemPrefersDark = mediaQuery.matches;
-                setCurrentTheme(systemPrefersDark ? "dark" : "light");
-                setIsDarkMode(systemPrefersDark);
-            } else {
-                setCurrentTheme(theme);
-                setIsDarkMode(theme === "dark");
-            }
-        };
-
-        // Initial check and listener
-        updateTheme();
-        if (theme === "auto") {
-            mediaQuery.addEventListener("change", updateTheme);
-        }
-
-        return () => {
-            mediaQuery.removeEventListener("change", updateTheme);
-        };
-    }, [theme]);
-
-    const videoColorScheme = isDarkMode ? "dark" : "light";
+    const { autoDetectedTheme } = useAutoDetectTheme();
 
     const handleImageClick = (imageName) => {
         const newImage = `${import.meta.env.BASE_URL}images/ispeaker/exam_images/fullsize/${imageName}.webp`;
@@ -183,7 +154,7 @@ const WatchAndStudyTab = ({ videoUrl, subtitleUrl, taskData, dialog, skills }) =
                                         <MediaProvider />
                                         <DefaultVideoLayout
                                             icons={defaultLayoutIcons}
-                                            colorScheme={videoColorScheme}
+                                            colorScheme={autoDetectedTheme}
                                         />
                                         <Track
                                             src={subtitleUrl}

--- a/src/components/general/LogoLightOrDark.jsx
+++ b/src/components/general/LogoLightOrDark.jsx
@@ -1,36 +1,13 @@
 import PropTypes from "prop-types";
-import { useEffect, useState } from "react";
-import { useTheme } from "../../utils/ThemeContext/useTheme";
+import { useAutoDetectTheme } from "../../utils/ThemeContext/useAutoDetectTheme";
 
 const LogoLightOrDark = ({ width, height }) => {
-    const { theme } = useTheme();
-    const [isDarkMode, setIsDarkMode] = useState(false);
+    const { autoDetectedTheme } = useAutoDetectTheme();
 
-    useEffect(() => {
-        const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-
-        const updateTheme = () => {
-            const systemPrefersDark = mediaQuery.matches;
-            const newIsDarkMode = theme === "auto" ? systemPrefersDark : theme === "dark";
-
-            if (newIsDarkMode !== isDarkMode) {
-                setIsDarkMode(newIsDarkMode);
-            }
-        };
-
-        updateTheme();
-        if (theme === "auto") {
-            mediaQuery.addEventListener("change", updateTheme);
-        }
-
-        return () => {
-            mediaQuery.removeEventListener("change", updateTheme);
-        };
-    }, [theme, isDarkMode]);
-
-    const logoSrc = isDarkMode
-        ? `${import.meta.env.BASE_URL}images/logos/ispeakerreact-no-background-darkmode.svg`
-        : `${import.meta.env.BASE_URL}images/logos/ispeakerreact-no-background.svg`;
+    const logoSrc =
+        autoDetectedTheme === "dark"
+            ? `${import.meta.env.BASE_URL}images/logos/ispeakerreact-no-background-darkmode.svg`
+            : `${import.meta.env.BASE_URL}images/logos/ispeakerreact-no-background.svg`;
 
     return <img alt="iSpeakerReact logo" src={logoSrc} width={width} height={height} />;
 };

--- a/src/components/general/TopNavBar.jsx
+++ b/src/components/general/TopNavBar.jsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import { BsAlphabet, BsCardChecklist, BsChatText } from "react-icons/bs";
 import { CgMenuLeft } from "react-icons/cg";
 import { FaGithub } from "react-icons/fa";
@@ -9,45 +8,20 @@ import { PiExam } from "react-icons/pi";
 
 import { useTranslation } from "react-i18next";
 import { NavLink, useLocation } from "react-router-dom";
-import { useTheme } from "../../utils/ThemeContext/useTheme";
+import { useAutoDetectTheme } from "../../utils/ThemeContext/useAutoDetectTheme";
 import openExternal from "../../utils/openExternal";
 
 const TopNavBar = () => {
     const { t } = useTranslation();
-    const { theme } = useTheme();
+    const { autoDetectedTheme } = useAutoDetectTheme();
     const location = useLocation();
-    const [, setCurrentTheme] = useState(theme);
-    const [isDarkMode, setIsDarkMode] = useState(false);
 
-    useEffect(() => {
-        const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    const logoSrc =
+        autoDetectedTheme === "dark"
+            ? `${import.meta.env.BASE_URL}images/logos/ispeakerreact-no-background-darkmode.svg`
+            : `${import.meta.env.BASE_URL}images/logos/ispeakerreact-no-background.svg`;
 
-        const updateTheme = () => {
-            if (theme === "auto") {
-                const systemPrefersDark = mediaQuery.matches;
-                setCurrentTheme(systemPrefersDark ? "dark" : "light");
-                setIsDarkMode(systemPrefersDark);
-            } else {
-                setCurrentTheme(theme);
-                setIsDarkMode(theme === "dark");
-            }
-        };
-
-        updateTheme();
-        if (theme === "auto") {
-            mediaQuery.addEventListener("change", updateTheme);
-        }
-
-        return () => {
-            mediaQuery.removeEventListener("change", updateTheme);
-        };
-    }, [theme]);
-
-    const logoSrc = isDarkMode
-        ? `${import.meta.env.BASE_URL}images/logos/ispeakerreact-no-background-darkmode.svg`
-        : `${import.meta.env.BASE_URL}images/logos/ispeakerreact-no-background.svg`;
-
-    const navbarClass = isDarkMode ? "bg-slate-600/50" : "bg-lime-300/75";
+    const navbarClass = autoDetectedTheme === "dark" ? "bg-slate-600/50" : "bg-lime-300/75";
 
     const menuItems = [
         {
@@ -226,9 +200,7 @@ const TopNavBar = () => {
                 <button
                     type="button"
                     className="btn btn-ghost no-animation flex items-center"
-                    onClick={() =>
-                        openExternal("https://github.com/learnercraft/ispeakerreact/")
-                    }
+                    onClick={() => openExternal("https://github.com/learnercraft/ispeakerreact/")}
                 >
                     <FaGithub size="1.5em" />
                     <span className="ms-1 hidden items-center space-x-1 md:inline-flex">

--- a/src/components/sound_page/WatchVideoCard.jsx
+++ b/src/components/sound_page/WatchVideoCard.jsx
@@ -6,11 +6,13 @@ import PropTypes from "prop-types";
 import { useEffect, useState } from "react";
 import { IoInformationCircleOutline } from "react-icons/io5";
 import { isElectron } from "../../utils/isElectron";
+import { useAutoDetectTheme } from "../../utils/ThemeContext/useAutoDetectTheme";
 
 const WatchVideoCard = ({ videoData, accent, t, phoneme }) => {
     const [iframeLoading, setIframeLoading] = useState(true);
     const [localVideoUrl, setLocalVideoUrl] = useState(null);
     const [useOnlineVideo, setUseOnlineVideo] = useState(false);
+    const { autoDetectedTheme } = useAutoDetectTheme();
 
     useEffect(() => {
         const checkLocalVideo = async () => {
@@ -81,7 +83,7 @@ const WatchVideoCard = ({ videoData, accent, t, phoneme }) => {
                                         <MediaProvider />
                                         <DefaultVideoLayout
                                             icons={defaultLayoutIcons}
-                                            colorScheme="light"
+                                            colorScheme={autoDetectedTheme}
                                         />
                                     </MediaPlayer>
                                 ) : (

--- a/src/components/sound_page/hooks/useSoundVideoDialog.jsx
+++ b/src/components/sound_page/hooks/useSoundVideoDialog.jsx
@@ -1,9 +1,9 @@
 import { MediaPlayer, MediaProvider } from "@vidstack/react";
 import { defaultLayoutIcons, DefaultVideoLayout } from "@vidstack/react/player/layouts/default";
 import PropTypes from "prop-types";
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { IoInformationCircleOutline } from "react-icons/io5";
-import { useTheme } from "../../../utils/ThemeContext/useTheme";
+import { useAutoDetectTheme } from "../../../utils/ThemeContext/useAutoDetectTheme";
 import { SoundVideoDialogContext } from "./useSoundVideoDialogContext";
 
 export const SoundVideoDialogProvider = ({ children, t }) => {
@@ -24,26 +24,7 @@ export const SoundVideoDialogProvider = ({ children, t }) => {
 
     const dialogRef = useRef(null);
     const mediaPlayerRef = useRef(null);
-    const { theme } = useTheme();
-    const [isDarkMode, setIsDarkMode] = useState(false);
-
-    useEffect(() => {
-        const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-
-        const updateTheme = () => {
-            const systemPrefersDark = mediaQuery.matches;
-            setIsDarkMode(theme === "auto" ? systemPrefersDark : theme === "dark");
-        };
-
-        updateTheme();
-        if (theme === "auto") {
-            mediaQuery.addEventListener("change", updateTheme);
-        }
-
-        return () => {
-            mediaQuery.removeEventListener("change", updateTheme);
-        };
-    }, [theme]);
+    const { autoDetectedTheme } = useAutoDetectTheme();
 
     const showDialog = (state) => {
         setDialogState({ ...state, isOpen: true, iframeLoading: true });
@@ -100,7 +81,7 @@ export const SoundVideoDialogProvider = ({ children, t }) => {
                                         <MediaProvider />
                                         <DefaultVideoLayout
                                             icons={defaultLayoutIcons}
-                                            colorScheme={isDarkMode ? "dark" : "light"}
+                                            colorScheme={autoDetectedTheme}
                                         />
                                     </MediaPlayer>
                                 ) : dialogState.isOpen && dialogState.videoUrl ? (

--- a/src/components/word_page/RecordingWaveform.jsx
+++ b/src/components/word_page/RecordingWaveform.jsx
@@ -11,7 +11,6 @@ import {
 } from "../../utils/databaseOperations";
 import { isElectron } from "../../utils/isElectron";
 import { sonnerErrorToast, sonnerSuccessToast } from "../../utils/sonnerCustomToast";
-import { useTheme } from "../../utils/ThemeContext/useTheme";
 import useWaveformTheme from "./useWaveformTheme";
 
 const getSupportedMimeType = () => {
@@ -36,8 +35,6 @@ const RecordingWaveform = ({
     isAudioLoading = false,
     t,
 }) => {
-    const { theme } = useTheme();
-
     const waveformRef = useRef(null);
     const [recording, setRecording] = useState(false);
     const [recordedUrl, setRecordedUrl] = useState(null);
@@ -55,7 +52,6 @@ const RecordingWaveform = ({
     const cursorDark = "hsl(82 84.5% 67.1%)"; // Dark mode progress color
 
     const { waveformColor, progressColor, cursorColor } = useWaveformTheme(
-        theme,
         waveformLight,
         waveformDark,
         progressLight,

--- a/src/components/word_page/WordDetails.jsx
+++ b/src/components/word_page/WordDetails.jsx
@@ -1,20 +1,17 @@
 import WavesurferPlayer from "@wavesurfer/react";
 import PropTypes from "prop-types";
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { BsPauseFill, BsPlayFill } from "react-icons/bs";
 import { IoChevronBackOutline, IoInformationCircleOutline } from "react-icons/io5";
 import { VscFeedback } from "react-icons/vsc";
 import { checkRecordingExists } from "../../utils/databaseOperations";
 import openExternal from "../../utils/openExternal";
-import { useTheme } from "../../utils/ThemeContext/useTheme";
 import RecordingWaveform from "./RecordingWaveform";
 import ReviewRecording from "./ReviewRecording";
 import { parseIPA } from "./syllableParser";
 import useWaveformTheme from "./useWaveformTheme";
 
 const WordDetails = ({ word, handleBack, t, accent, onReviewUpdate, scrollRef }) => {
-    const { theme } = useTheme();
-
     const [activeSyllable, setActiveSyllable] = useState(-1);
     const [isPlaying, setIsPlaying] = useState(false);
     const [isAudioLoading, setIsAudioLoading] = useState(true); // State to track loading
@@ -33,7 +30,6 @@ const WordDetails = ({ word, handleBack, t, accent, onReviewUpdate, scrollRef })
     const cursorDark = "hsl(258.3 89.5% 66.3%)"; // Dark mode progress color
 
     const { waveformColor, progressColor, cursorColor } = useWaveformTheme(
-        theme,
         waveformLight,
         waveformDark,
         progressLight,
@@ -199,7 +195,8 @@ const WordDetails = ({ word, handleBack, t, accent, onReviewUpdate, scrollRef })
                             <IoInformationCircleOutline
                                 className="h-6 w-6"
                                 onClick={() =>
-                                    wordPronunInfoModalRef.current && wordPronunInfoModalRef.current.showModal()
+                                    wordPronunInfoModalRef.current &&
+                                    wordPronunInfoModalRef.current.showModal()
                                 }
                             />
                         </button>

--- a/src/components/word_page/useWaveformTheme.jsx
+++ b/src/components/word_page/useWaveformTheme.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 
 const useWaveformTheme = (
     theme,

--- a/src/components/word_page/useWaveformTheme.jsx
+++ b/src/components/word_page/useWaveformTheme.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
+import { useAutoDetectTheme } from "../../utils/ThemeContext/useAutoDetectTheme";
 
 const useWaveformTheme = (
-    theme,
     waveformLight,
     waveformDark,
     progressLight,
@@ -9,6 +9,7 @@ const useWaveformTheme = (
     cursorLight,
     cursorDark
 ) => {
+    const { autoDetectedTheme } = useAutoDetectTheme();
     const [colors, setColors] = useState({
         waveformColor: waveformLight,
         progressColor: progressLight,
@@ -16,29 +17,20 @@ const useWaveformTheme = (
     });
 
     useEffect(() => {
-        const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-
-        const updateColors = () => {
-            const systemPrefersDark = mediaQuery.matches;
-            const isDarkMode = theme === "auto" ? systemPrefersDark : theme === "dark";
-
-            setColors({
-                waveformColor: isDarkMode ? waveformDark : waveformLight,
-                progressColor: isDarkMode ? progressDark : progressLight,
-                cursorColor: isDarkMode ? cursorDark : cursorLight,
-            });
-        };
-
-        updateColors();
-
-        if (theme === "auto") {
-            mediaQuery.addEventListener("change", updateColors);
-        }
-
-        return () => {
-            mediaQuery.removeEventListener("change", updateColors);
-        };
-    }, [theme, waveformLight, waveformDark, progressLight, progressDark, cursorLight, cursorDark]);
+        setColors({
+            waveformColor: autoDetectedTheme === "dark" ? waveformDark : waveformLight,
+            progressColor: autoDetectedTheme === "dark" ? progressDark : progressLight,
+            cursorColor: autoDetectedTheme === "dark" ? cursorDark : cursorLight,
+        });
+    }, [
+        autoDetectedTheme,
+        waveformLight,
+        waveformDark,
+        progressLight,
+        progressDark,
+        cursorLight,
+        cursorDark,
+    ]);
 
     return colors;
 };

--- a/src/utils/ThemeContext/useAutoDetectTheme.jsx
+++ b/src/utils/ThemeContext/useAutoDetectTheme.jsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+import { useTheme } from "./useTheme";
+
+export function useAutoDetectTheme() {
+    const { theme } = useTheme();
+    const [isDarkMode, setIsDarkMode] = useState(false);
+    const [autoDetectedTheme, setAutoDetectedTheme] = useState(theme);
+
+    useEffect(() => {
+        const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+
+        const updateTheme = () => {
+            if (theme === "auto") {
+                const systemPrefersDark = mediaQuery.matches;
+                setAutoDetectedTheme(systemPrefersDark ? "dark" : "light");
+                setIsDarkMode(systemPrefersDark);
+            } else {
+                setAutoDetectedTheme(theme);
+                setIsDarkMode(theme === "dark");
+            }
+        };
+
+        updateTheme();
+        if (theme === "auto") {
+            mediaQuery.addEventListener("change", updateTheme);
+        }
+        return () => {
+            mediaQuery.removeEventListener("change", updateTheme);
+        };
+    }, [theme]);
+
+    return { isDarkMode, autoDetectedTheme };
+}


### PR DESCRIPTION
This PR refactors theme detection logic to improve reusability and maintainability across the codebase:

- Extracts theme and dark mode detection into a new `useAutoDetectTheme` utility hook, which leverages the app's theme context and system preferences.
- Refactors the `useWaveformTheme` hook to use `useAutoDetectTheme` for determining dark/light mode, removing the need for a `theme` prop, and being consistent with the user's app settings and system preferences.